### PR TITLE
Optimise synth render path for realtime performance

### DIFF
--- a/Core/include/audioRender.hpp
+++ b/Core/include/audioRender.hpp
@@ -10,7 +10,7 @@
 
 class AudioRender : public TromboneSynth {
 public:
-    static constexpr int frames = 512;
+    static constexpr int frames = 128;
     static constexpr int sample_rate = 44100;
 
     AudioRender();

--- a/Core/include/envelope.hpp
+++ b/Core/include/envelope.hpp
@@ -50,7 +50,7 @@ class Envelope{
          *                          times the `getAmplitude()` function is called
          *                          upon.
          */
-        Envelope(int attack_in = 100, int decay_in = 20, float sustain_in = 0.98, int rest_in = 10);
+        Envelope(int attack_in = 10, int decay_in = 20, float sustain_in = 0.98, int rest_in = 10);
 
         /** @brief                  The destructor function for the `Envelope` class
          *                          which is currently just set to default.

--- a/Core/include/synth.hpp
+++ b/Core/include/synth.hpp
@@ -15,6 +15,8 @@
 /* Addition of all necessary header files. */
 #include <cmath>
 #include <sys/time.h>
+#include <array>
+#include <algorithm>
 
 /* ========================================================================================== */
 /*                                  Class definitions                                         */
@@ -404,7 +406,7 @@ class OctavesWithHarmonics :    public Octaves
          *  @param  n       The number of harmonics
          *  @retval         The maximum amplitude possible as a floating point value.
          */
-        float getHarmomicDecayMax(int n);
+        float getHarmonicDecayMax(int n);
 
         /** @brief          A function that can change the value of the decay constant
          *                  used to set the maxmimum amplitude of each successive 
@@ -421,9 +423,17 @@ class OctavesWithHarmonics :    public Octaves
          */
         float getDecayConstant(void);
         
-    private:
-        float decayConstant = 0.1;
-        
+    protected:
+
+        static constexpr int maxHarmonics = 64;
+
+        float decayConstant = 0.1f;
+
+        std::array<float, maxHarmonics> harmonicWeights{};
+        int cachedNHarmonics = 0;
+        bool harmonicCacheDirty = true;
+
+        void updateHarmonicCache(int n);
 };
 
 

--- a/Core/include/tromboneSynth.hpp
+++ b/Core/include/tromboneSynth.hpp
@@ -1,11 +1,11 @@
-/** @file       tromboneSynth.hpp
- *  @author     Ryan McBride
- *  @brief      A file to declare the synthesiser parameters and functions
- *              for the trombone specifically using the classes and methods
- *              declared in the `synth.hpp` file.
- */
+    /** @file       tromboneSynth.hpp
+     *  @author     Ryan McBride
+     *  @brief      A file to declare the synthesiser parameters and functions
+     *              for the trombone specifically using the classes and methods
+     *              declared in the `synth.hpp` file.
+     */
 
- /* Preventing recurssion */
+    /* Preventing recurssion */
  #pragma once
 
  /* Adding the necessary header files to be included. */
@@ -32,8 +32,8 @@
          *  @param  rest            The amount of time in milliseconds that the rest
                                     stage should last for.
          */
-        TromboneSynth(int sampleRate = 44100, float attack = 25.0, float decay = 50.0,
-             float sustain = 0.99, float rest = 10.0);
+        TromboneSynth(int sampleRate = 44100, float attack = 10.0f, float decay = 50.0f,
+             float sustain = 1.0f, float rest = 10.0f);
 
         /**    @brief              A function which may be called to set the
          *                         note and octave of a new sound by the user.
@@ -189,17 +189,25 @@
         permanently. The ADSR values may need to be adjusted but this should sound
         brassy. */
 
-        Envelope tromboneEnvelope = Envelope(100, 50, 0.95f, 10);
-        float attack_ms;        /*  The attack time in milliseconds of the envelope. */
-        float decay_ms;         /*  The decay time in milliseconds of the envelope. */
-        float rest_ms;          /*  The rest time in milliseconds of the envelope. */
-        float sustain;          /*  The sustain level of the envelope. */
+        Envelope tromboneEnvelope = Envelope(10, 50, 1.0f, 10);
+
+        float attack_ms = 10.0f;        /*  The attack time in milliseconds of the envelope. */
+        float decay_ms = 50.0f;         /*  The decay time in milliseconds of the envelope. */
+        float rest_ms = 10.0f;          /*  The rest time in milliseconds of the envelope. */
+        float sustain = 1.0f;          /*  The sustain level of the envelope. */
+
+        float cachedFrequency = 0.0f;
+        float cachedPhaseIncrement = 0.0f;
+        bool pitchCacheDirty = true;
+
+        void updatePitchCache();
+
 
         float phase = 0.0f; /* Phase of oscillator wave */
 
         /*  synth   */
         int nHarmonics = 17;    /*  The number of harmonics which will be present in the final signal. */
-        int octave = 2;         /*  The octave which the note will be present in. */
+        int octave = 4;         /*  The octave which the note will be present in. */
         Notes::Notes_t note = Notes::Notes::note_A;  /*  The note which will be played. */
         int pitchBend   =   8192;  /*  The MIDI message pitch bend dependent upon the position of the slider. */
 

--- a/Core/src/drivers/audio_output.cpp
+++ b/Core/src/drivers/audio_output.cpp
@@ -16,7 +16,7 @@ AudioOutput::AudioOutput() {
         1,          // mono
         44100,      // sample rate
         1,          // allow resampling
-        500000      // latency in us
+        5000      // latency in us
     );
 
     if (err < 0) {

--- a/Core/src/synth.cpp
+++ b/Core/src/synth.cpp
@@ -282,46 +282,84 @@ float Octaves::PlayingFrequency(float phase){
 /*                                                                                            */
 /* ========================================================================================== */
 
-OctavesWithHarmonics::OctavesWithHarmonics(){
-
+OctavesWithHarmonics::OctavesWithHarmonics()
+{
 }
 
-float OctavesWithHarmonics::PlayingNoteWithHarmonics(int n, int octave, Notes_t note, float phase){
+void OctavesWithHarmonics::updateHarmonicCache(int n)
+{
+    n = std::max(1, std::min(n, maxHarmonics));
+
+    if (!harmonicCacheDirty && cachedNHarmonics == n)
+        return;
+
+    float amplitudeSum = 0.0f;
+    for (int i = 0; i < n; ++i) {
+        harmonicWeights[i] = HarmonicDecay(i + 1);
+        amplitudeSum += harmonicWeights[i];
+    }
+
+    if (amplitudeSum > 0.0f) {
+        for (int i = 0; i < n; ++i) {
+            harmonicWeights[i] /= amplitudeSum;
+        }
+    }
+
+    cachedNHarmonics = n;
+    harmonicCacheDirty = false;
+}
+
+float OctavesWithHarmonics::PlayingNoteWithHarmonics(int n, int octave, Notes_t note, float phase)
+{
     return PlayingFrequencyWithHarmonics(n, phase);
 }
 
-float OctavesWithHarmonics::PlayingFrequencyWithHarmonics(int n, float phase){
-    float outputAmplitude = 0.0f;
-    /*  Ensuring that there has been a value of n above 1 being passed. */
-    n = std::max(n, 1);
 
-    for (int harmonicNumber=1; harmonicNumber < n+1; harmonicNumber++)
+float OctavesWithHarmonics::PlayingFrequencyWithHarmonics(int n, float phase)
+{
+    updateHarmonicCache(n);
+
+    const float c1 = std::cos(phase);
+
+    float cos_n_minus_1 = 1.0f; // cos(0 * phase)
+    float cos_n = c1;           // cos(1 * phase)
+
+    float outputAmplitude = harmonicWeights[0] * cos_n;
+
+    for (int harmonicNumber = 2; harmonicNumber <= cachedNHarmonics; ++harmonicNumber)
     {
-        outputAmplitude += HarmonicDecay(harmonicNumber) * std::cos(phase*harmonicNumber);
-    } 
+        float cos_n_plus_1 = 2.0f * c1 * cos_n - cos_n_minus_1;
+        outputAmplitude += harmonicWeights[harmonicNumber - 1] * cos_n_plus_1;
 
-    /*  Returning the normalised ampltide.*/
-    return outputAmplitude/getHarmomicDecayMax(n);
+        cos_n_minus_1 = cos_n;
+        cos_n = cos_n_plus_1;
+    }
+
+    return outputAmplitude;
 }
 
-float OctavesWithHarmonics::HarmonicDecay(int n){
+float OctavesWithHarmonics::HarmonicDecay(int n)
+{
     /*  Setting the minimum influence of the harmonics being tested to be 1%. */
     return std::max(1.0f - (decayConstant * std::abs((n+1) - 1)), 0.0000001f);
 }
 
-float OctavesWithHarmonics::getHarmomicDecayMax(int n){
+float OctavesWithHarmonics::getHarmonicDecayMax(int n)
+{
     float amplitude = 0.0f;
-    for (int i=0; i<n; i++){
-        amplitude += HarmonicDecay(i+1);
+    for (int i = 0; i < n; i++) {
+        amplitude += HarmonicDecay(i + 1);
     }
     return amplitude;
-
 }
 
-void OctavesWithHarmonics::setDecayConstant(float decayC){
+void OctavesWithHarmonics::setDecayConstant(float decayC)
+{
     decayConstant = decayC;
+    harmonicCacheDirty = true;
 }
 
-float OctavesWithHarmonics::getDecayConstant(void){
+float OctavesWithHarmonics::getDecayConstant(void)
+{
     return decayConstant;
 }

--- a/Core/src/tromboneSynth.cpp
+++ b/Core/src/tromboneSynth.cpp
@@ -1,9 +1,9 @@
-/** @file       tromboneSynth.cpp
- *  @author     Ryan McBride
- *  @brief      A file to define the synthesiser parameters and functions
- *              for the trombone specifically using the classes and methods
- *              declared in the `synth.hpp` file.
- */
+    /** @file       tromboneSynth.cpp
+     *  @author     Ryan McBride
+     *  @brief      A file to define the synthesiser parameters and functions
+     *              for the trombone specifically using the classes and methods
+     *              declared in the `synth.hpp` file.
+     */
 
  /* Adding the necessary header files to be included. */
  #include "tromboneSynth.hpp"
@@ -33,29 +33,39 @@
     tromboneEnvelope.setRest(rest);
  }
 
+void TromboneSynth::updatePitchCache()
+{
+    cachedFrequency = getAdjustedFrequency();
+    cachedPhaseIncrement = 2.0f * static_cast<float>(M_PI) * cachedFrequency / static_cast<float>(sampleRate);
+    pitchCacheDirty = false;
+}
+
  void TromboneSynth::StartTromboneNote(Notes::Notes_t note_in, int octave_in){
     note = note_in;
     octave = octave_in;
+    pitchCacheDirty = true;
     tromboneEnvelope.startEnvelope();
  }
 
- void TromboneSynth::ChangeTromboneNote(Notes::Notes_t note_in, int octave_in){
+void TromboneSynth::ChangeTromboneNote(Notes::Notes_t note_in, int octave_in){
     note = note_in;
     octave = octave_in;
- }
+    pitchCacheDirty = true;
+}
  
- /* Change this to be based on frequency with the base note and using the pitch bend.*/
- float TromboneSynth::ReadTromboneAudio(void){
-    float freq = getAdjustedFrequency();
-    float phaseIncrement = 2.0f * static_cast<float>(M_PI) * freq / static_cast<float>(sampleRate);
+float TromboneSynth::ReadTromboneAudio(void){
+    if (pitchCacheDirty) {
+        updatePitchCache();
+    }
 
-    phase += phaseIncrement;
+    phase += cachedPhaseIncrement;
     if (phase >= 2.0f * static_cast<float>(M_PI))
     {
         phase = std::fmod(phase, 2.0f * static_cast<float>(M_PI));
     }
+
     return tromboneEnvelope.getAmplitude() * PlayingFrequencyWithHarmonics(nHarmonics, phase);
- }
+}
 
  void TromboneSynth::StopTromboneNote(void){
    tromboneEnvelope.endEnvelope();
@@ -67,12 +77,10 @@ void TromboneSynth::NewTromboneNoteMIDI(int MIDINote){
     const int nNotes = 12;
 
     note = static_cast<Notes::Notes_t>(MIDINote % nNotes);
-
-    // MIDI standard: C4 = 60 → octave 4
     octave = (MIDINote / nNotes) - 1;
-
-    // clamp to available octave range
     octave = std::clamp(octave, 0, nOctaves - 1);
+
+    pitchCacheDirty = true;
 }
 
 void TromboneSynth::HandleMIDINoteOn(){
@@ -150,7 +158,7 @@ Notes::Notes_t TromboneSynth::getNote(void){
 
 void TromboneSynth::setPitchBend(int bend){
     pitchBend = bend;
-    return;
+    pitchCacheDirty = true;
 }
 
 int TromboneSynth::getPitchBend(void){

--- a/Core/temp_tests/rendering_internal_synth.cpp
+++ b/Core/temp_tests/rendering_internal_synth.cpp
@@ -71,10 +71,10 @@ int main() {
                     break;
 
                 case RawInputEvent::Type::PressureReading:
-                    if (event.pressureReading < 0.22f && !pressure_gate) {
+                    if (event.pressureReading < 0.24f && !pressure_gate) {
                         coordinator.PressureEdge(true);
                         pressure_gate = true;
-                    } else if (event.pressureReading > 0.22f && pressure_gate) {
+                    } else if (event.pressureReading > 0.24f && pressure_gate) {
                         coordinator.PressureEdge(false);
                         pressure_gate = false;
                     }


### PR DESCRIPTION
- Cache harmonic weights to avoid recomputation per sample
- Cache pitch-dependent phase increment (update on note/bend change only)
- Replace per-harmonic cos(n·phase) with recurrence (1 trig call per sample)
- Remove redundant per-sample normalisation work
- Reduce CPU load in audio thread to support lower latency